### PR TITLE
Comment with correct target branch of unmergeable PR

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -46,14 +46,14 @@ post '/pull_request' do
   end
 
   pull_request.labels = ["Needs testing", "Not yet reviewed"] if pr_action == 'opened'
-  unless pull_request.mergeable?
+  if pull_request.dirty?
     message = <<EOM
-@#{pull_request.author}, this pull request is currently not mergeable. Please rebase against the develop branch and push again.
+@#{pull_request.author}, this pull request is currently not mergeable. Please rebase against the #{pull_request.target_branch} branch and push again.
 
 If you have a remote called 'upstream' that points to this repository, you can do this by running:
 
 ```
-    $ git pull --rebase upstream develop
+    $ git pull --rebase upstream #{pull_request.target_branch}
 ```
 
 ---------------------------------------

--- a/github/pull_request.rb
+++ b/github/pull_request.rb
@@ -25,12 +25,16 @@ class PullRequest
     @raw_data['created_at'] == @raw_data['updated_at']
   end
 
-  def mergeable?
-    @raw_data['mergeable']
+  def dirty?
+    @raw_data['mergeable_state'] == 'dirty' && @raw_data['mergeable'] == false
   end
 
   def author
     @raw_data['user']['login']
+  end
+
+  def target_branch
+    @raw_data['base']['ref']
   end
 
   def labels=(pr_labels)


### PR DESCRIPTION
This leaves a comment asking to rebase against the target branch the user is submitting a PR to, and also checks for the dirtiness of the PR by looking at the mergeable_state attribute
