### PR TITLE
Retry retrieval of PR commits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gem 'rack', '>= 1.5.2'
 gem 'sinatra'
 gem 'rest_client'
 gem "octokit", "~> 3.0"
+gem 'retriable', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
       rack
     rest_client (1.7.3)
       netrc (~> 0.7.7)
+    retriable (1.4.1)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
@@ -29,4 +30,5 @@ DEPENDENCIES
   octokit (~> 3.0)
   rack (>= 1.5.2)
   rest_client
+  retriable (~> 1.0)
   sinatra


### PR DESCRIPTION
The GitHub API appears to return a 404 sometimes when retrieving
commits for a newly created PR, so retry a few times.

Fixes #33