### PR TITLE
Ignore URLs in commit message line lengths

### DIFF
--- a/github/pull_request.rb
+++ b/github/pull_request.rb
@@ -1,5 +1,6 @@
 require 'octokit'
 require 'retriable'
+require 'uri'
 
 class PullRequest
 
@@ -59,7 +60,7 @@ class PullRequest
         warnings += "  * length of the first commit message line for #{commit.sha} exceeds 65 characters\n"
       end
       commit.commit.message.lines.each do |line|
-        if line.chomp.size > 72 && line !~ /^\s{4,}/
+        if line.chomp.sub(URI.regexp, '').size > 72 && line !~ /^\s{4,}/
           warnings += "  * commit message for #{commit.sha} is not wrapped at 72nd column\n"
         end
       end


### PR DESCRIPTION
Prevents warning on a commit message such as:

<pre>
Rails source where relative controller is assumed by url_for if no named
route was given (the :use_route option):
https://github.com/rails/rails/blob/v4.2.6/actionpack/lib/action_dispatch/routing/route_set.rb#L695-L698
</pre>

I think this is quite reasonable and better than using a URL shortener as it's a permanent URL that avoids a dependency on both a shortener service and even GitHub - it's quite usable if you even had a copy of the Rails release or repo with the data in the URL.

(https://github.com/theforeman/foreman/pull/3564#issuecomment-223237738)