### PR TITLE
Do not initiate tests if WiP is set

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -84,7 +84,7 @@ EOM
     actions['github'] = true
   end
 
-  if ENV['JENKINS_TOKEN']
+  if ENV['JENKINS_TOKEN'] && !pull_request.labels.include?("Work In Progress")
     jenkins = Jenkins.new
     jenkins.build(repo, pr_number)
     actions['jenkins'] = true


### PR DESCRIPTION
Here is an idea - if WiP (new label) is set, do not initiate tests. I plan to
push several times my UEFI and I don't want to block Jenkins for no reason.