### PR TITLE
For Katello pull requests set release to untriaged

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -41,7 +41,14 @@ post '/pull_request' do
       user_id = users[pull_request.author] if users.key?(pull_request.author)
 
       unless issue.rejected?
-        issue.set_version(current_version['id']) if issue.version.nil? && current_version
+        if project.name == 'Katello' && issue.release == 'Backlog'
+          issue.set_release(nil)
+        end
+
+        if issue.version.nil? && current_version
+          issue.set_version(current_version['id'])
+        end
+
         issue.add_pull_request(pull_request.raw_data['html_url'])
         issue.set_status(Issue::READY_FOR_TESTING) unless issue.closed?
         issue.set_assigned(user_id) unless user_id.nil? || user_id.empty? || issue.assigned_to

--- a/redmine/issue.rb
+++ b/redmine/issue.rb
@@ -22,8 +22,17 @@ class Issue < RedmineResource
     @raw_data['issue']['assigned_to']['name'] if @raw_data['issue']['assigned_to']
   end
 
+  def release
+    @raw_data['issue']['release']['release']['name']
+  end
+
   def set_version(version_id)
     @raw_data['issue']['fixed_version_id'] = version_id
+    self
+  end
+
+  def set_release(release_id)
+    @raw_data['issue']['release_id'] = release_id
     self
   end
 

--- a/redmine/project.rb
+++ b/redmine/project.rb
@@ -8,6 +8,10 @@ class Project < RedmineResource
     '/projects'
   end
 
+  def name
+    @raw_data['project']['name']
+  end
+
   def get_versions
     get("#{@raw_data['project']['id']}/versions")
   end

--- a/redmine/redmine_resource.rb
+++ b/redmine/redmine_resource.rb
@@ -8,9 +8,8 @@ class RedmineResource
   attr_reader :resource
   attr_accessor :base_path, :raw_data
 
-  def initialize(path = nil)
+  def initialize(path = nil, key = ENV['REDMINE_API_KEY'])
     site = 'http://projects.theforeman.org/'
-    key = ENV['REDMINE_API_KEY']
 
     options = {}
     options[:headers] = {'X-Redmine-API-Key' => key} if key


### PR DESCRIPTION
Katello projects in Redmine use empty release to indicate untriaged
issues, when pull requests are opened or closed and the release is
set to our backlog we want these to moved to untriaged. That ensures
that these issues get consideration during triage sessions for
release parsing.