### PR TITLE
Add route to view recent logs for erroring viewing

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -112,6 +112,16 @@ get '/status' do
   erb :status, :locals => locals
 end
 
+get '/logs' do
+  locals = {}
+
+  if (log_dir = ENV['OPENSHIFT_LOG_DIR'])
+    locals[:logs] = File.read("#{log_dir}/ruby.log")
+  end
+
+  erb :logs, :locals => locals
+end
+
 def verify_signature(payload_body)
   signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['GITHUB_SECRET_TOKEN'], payload_body)
   return halt 500, "Signatures didn't match!" unless Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'])

--- a/views/logs.erb
+++ b/views/logs.erb
@@ -1,0 +1,5 @@
+<h1>Recent Logs</h1>
+
+<pre>
+<%= logs %>
+</pre>


### PR DESCRIPTION
Thinking about the most recent issue where an in production error was thrown and limited ability to view logs, this might help developers make changes and then address issues with less of a bottleneck. This is a very broad splat everything in the log file. We could consider trying to implement more direct error logging and display.