### PR TITLE
Add PR processor to smart_proxy_openscap

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -169,6 +169,7 @@ theforeman/smart_proxy_monitoring:
 theforeman/smart_proxy_omaha:
   pr_scanner: true
 theforeman/smart_proxy_openscap:
+  pr_scanner: true
   redmine: foreman_openscap
   redmine_required: true
 theforeman/smart_proxy_pulp:


### PR DESCRIPTION
once https://github.com/theforeman/foreman-infra/pull/268 and this is merged, I'd like to ask @domcleal or @ohadlevy to 

* add PrProcessor webhook to  smart_proxy_openscap GitHub repo
* add the  smart_proxy_openscap repo to the Bots team with write access

as far as I understood from http://projects.theforeman.org/projects/foreman/wiki/Jenkins#Adding-a-new-smart-proxy-plugin only org admins can do it