### PR TITLE
Add use of OAuth token for running the add_webhook script

### DIFF
--- a/scripts/add_webhook.sh
+++ b/scripts/add_webhook.sh
@@ -16,19 +16,24 @@ if [ -z "${GITHUB_SECRET_TOKEN}" ]; then
   exit 1
 fi
 
+if [ -z "${GITHUB_AUTH_TOKEN}" ]; then
+  echo "GITHUB_AUTH_TOKEN is needed to access the GitHub API"
+  exit 1
+fi
+
 url=http://prprocessor-theforeman.rhcloud.com/pull_request
 
 t=$(mktemp)
 for repo in $*; do
-  echo "Checking ${repo}"
-  curl -n https://api.github.com/repos/${repo}/hooks > $t
+  echo "Checking ${repo} : https://api.github.com/repos/${repo}/hooks"
+  curl -H "Authorization: token ${GITHUB_AUTH_TOKEN}" -n https://api.github.com/repos/${repo}/hooks > $t
   id=$(jgrep -i $t "name=web and config.url=${url}" -s id || :)
   if [ -n "$id" ]; then
     echo "Existing hook found on ${repo}, skipping"
     continue
   fi
   echo "Updating ${repo}, adding hook"
-  curl -nd '
+  curl -H "Authorization: token ${GITHUB_AUTH_TOKEN}" -nd '
   {
     "name": "web",
     "active": true,


### PR DESCRIPTION
When adding a webhook to foreman_maintain recently, I struggled to get this to work without an OAuth token. GitHub's docs suggest the best way to use such a token is via a curl header (https://developer.github.com/v3/guides/getting-started/#oauth) so I added this as an environment variable to the script