### PR TITLE
Move smart_proxy_dynflow under foreman-tasks project

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -182,7 +182,7 @@ theforeman/smart_proxy_dns_infoblox:
   redmine: infoblox
 theforeman/smart_proxy_dynflow:
   pr_scanner: true
-  redmine: foreman_remote_execution
+  redmine: foreman-tasks
   redmine_required: true
 theforeman/smart_proxy_monitoring:
   pr_scanner: true


### PR DESCRIPTION
it doesn't make much sense to have it under remote execution now