### PR TITLE
Set the client propery

### DIFF
--- a/github/pull_request.rb
+++ b/github/pull_request.rb
@@ -12,6 +12,7 @@ class PullRequest
     self.raw_data = raw_data
     self.title    = raw_data['title']
     self.number   = raw_data['number']
+    self.client   = client
 
     # Sometimes the GitHub API returns a 404 immediately after PR creation
     Retriable.retriable :on => Octokit::NotFound, :interval => 2, :tries => 10 do


### PR DESCRIPTION
fe16b84b3a033fd860f3859d4aedba90b9e3bf1a caused a regression where the @client propery was no longer set.