### PR TITLE
Only add branch labels if they're new

### DIFF
--- a/github/pull_request.rb
+++ b/github/pull_request.rb
@@ -180,8 +180,9 @@ EOM
   end
 
   def set_branch_labels(mapping)
-    labels = get_branch_labels(mapping)
-    self.labels = labels if labels.any?
+    new_labels = get_branch_labels(mapping)
+    to_add = new_labels - labels
+    self.labels = to_add if to_add.any?
   end
 
   private


### PR DESCRIPTION
1ea8acb1ca8dc9087111d1d1d0baf2d256bf30a2 added branch labels, but this ignored any labels that were already present.

The annoying current behavior can be seen in https://github.com/theforeman/foreman-packaging/pull/2201