### PR TITLE
Add more debug info on unconfigured repos

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -26,7 +26,7 @@ post '/pull_request' do
   event_act = "#{event}/#{action}"
 
   raise "unknown repo" unless payload['repository'] && (repo_name = payload['repository']['full_name'])
-  raise "repo not configured" if Repository[repo_name].nil?
+  raise "repo #{repo_name} not configured" if Repository[repo_name].nil?
   repo = Repository[repo_name]
 
   client = Octokit::Client.new(:access_token => ENV['GITHUB_OAUTH_TOKEN'])


### PR DESCRIPTION
I saw an error in production that wasn't helpful:

```
App 6108 stderr: 2018-05-04 16:07:33 - RuntimeError - repo not configured:
```