### PR TITLE
enable link_to_redmine for foreman_maintain

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -5,6 +5,7 @@
 #            assigns PRs to tickets, enforces ticket matches project when present
 #   redmine_required: enforce commit message format to include Redmine ticket number (default: false)
 #   refs: optional list of Redmine projects that commits here can "refs" (default: [])
+#   link_to_redmine: Add comment with Issue number if present (default: false)
 ---
 theforeman/chef-handler-foreman:
   redmine: chef
@@ -53,6 +54,7 @@ theforeman/foreman-installer:
 theforeman/foreman_maintain:
   redmine: foreman-maintain
   redmine_required: true
+  link_to_redmine: true
 theforeman/foreman_monitoring: {}
 theforeman/foreman-one:
   redmine: opennebula


### PR DESCRIPTION
ping @iNecas I found myself wanting this. If you don't I'm also okay without it, I guessed it wasn't added in 6bc2a67b4f4d34bfc4dd16819f283469d6f0c007 because it wasn't documented?