### PR TITLE
Add ui label to any change at webpack in Foreman

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -20,6 +20,8 @@ theforeman/foreman:
   redmine: foreman
   redmine_required: true
   link_to_redmine: true
+  directory_labels:
+    webpack: ui
 theforeman/foreman_abrt:
   redmine: abrt
 theforeman/foreman_ansible:


### PR DESCRIPTION
To make it easy for the UI team to filter pull requests that change the UI, a label is required.

Since most of the UI base code is placed in "webpack" any change to the webpack directory will add the "ui" label to the PR.

//cc @ohadlevy @ares @waldenraines @tbrisker 