### PR TITLE
Map label to PR according to nested path

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -121,7 +121,7 @@ EOM
       pull_request.add_comment(message)
     end
 
-    pull_request.set_directory_labels(repo.directory_labels) if repo.directory_labels?
+    pull_request.set_path_labels(repo.path_labels) if repo.path_labels?
     pull_request.set_branch_labels(repo.branch_labels) if repo.branch_labels?
 
     actions['github'] = true

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -11,7 +11,7 @@ theforeman/chef-handler-foreman:
   redmine: chef
 theforeman/community-templates:
   redmine: foreman
-  directory_labels:
+  path_labels:
     job_templates: Remote execution
     partition_tables_templates: Provisioning
     provisioning_templates: Provisioning
@@ -20,7 +20,7 @@ theforeman/foreman:
   redmine: foreman
   redmine_required: true
   link_to_redmine: true
-  directory_labels:
+  path_labels:
     .+-stable: Stable branch
     webpack: UI
 theforeman/foreman_abrt:

--- a/github/pull_request.rb
+++ b/github/pull_request.rb
@@ -187,9 +187,17 @@ EOM
     @client.create_status(repo.full_name, options[:sha], state, context: 'prprocessor', description: message, target_url: options[:url])
   end
 
-  def set_directory_labels(mapping)
+  def get_labels(filename, mapping)
+    mapping.select { |k, v| filename == k || filename.start_with?(k+"/") }.values
+  end
+
+  def get_desired_labels(files, mapping)
+    files.collect { |f| get_labels(f.filename, mapping) }.flatten.compact.uniq
+  end
+
+  def set_path_labels(mapping)
     files = client.pull_files(repo.full_name, number)
-    desired_labels = files.collect { |f| mapping[f.filename.split("/").first] }.compact.uniq
+    desired_labels = get_desired_labels(files, mapping) 
 
     to_remove = mapping.keys - desired_labels
     to_add = desired_labels

--- a/repository.rb
+++ b/repository.rb
@@ -56,12 +56,12 @@ class Repository
     @config['link_to_redmine']
   end
 
-  def directory_labels
-    @config['directory_labels']
+  def path_labels
+    @config['path_labels']
   end
 
-  def directory_labels?
-    @config['directory_labels']
+  def path_labels?
+    @config['path_labels']
   end
 
   def branch_labels

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,0 +1,13 @@
+require 'minitest/autorun'
+require 'repository'
+
+class TestRepoConfig < Minitest::Test
+  def test_path_labels_keys_does_not_contain_trailing_slash
+    paths = Repository.all.values
+      .select{ |r| r.path_labels? }
+      .map{ |r| r.path_labels.keys }
+      .flatten
+      .select { |file_path| file_path.end_with?('/') }
+    assert_equal [], paths, "remove trailing slash from the following paths: #{paths.join(', ')}"
+  end
+end

--- a/test/github/pull_request_test.rb
+++ b/test/github/pull_request_test.rb
@@ -52,6 +52,30 @@ class TestPullRequest < Minitest::Test
     assert_equal(pr.get_branch_labels(mapping), ['full', 'regex'])
   end
 
+  def test_get_desired_labels
+    pr = pull_request
+
+    mapping = {
+      'app/assets2' => 'ui',
+      'job_templates' => 'Remote execution',
+      'packages-lock.json' => 'packages',
+      'partition_tables_templates' => 'Provisioning',
+      'provisioning_templates' => 'Provisioning',
+    }
+
+    files = pull_files(['job_templates2/', 'app/job_templates/tmplt.erb', 'app/'])
+    assert_equal [], pr.get_desired_labels(files, mapping)
+
+    files = pull_files(['job_templates/', 'provisioning_templates/p.erb'])
+    assert_equal ['Remote execution', 'Provisioning'], pr.get_desired_labels(files, mapping)
+
+    files = pull_files(['partition_tables_templates/pt.erb', 'provisioning_templates/p.erb'])
+    assert_equal ['Provisioning'], pr.get_desired_labels(files, mapping)
+
+    files = pull_files(['packages-lock.json'])
+    assert_equal ['packages'], pr.get_desired_labels(files, mapping)
+  end
+
   private
 
   def pull_request(repo=nil, raw_data=nil, client=nil)
@@ -72,5 +96,12 @@ class TestPullRequest < Minitest::Test
     end
 
     PullRequest.new(repo, data, client)
+  end
+
+  def pull_files(file_paths)
+    file_paths.map do |fp| 
+      gh_file = Minitest::Mock.new
+      gh_file.expect :filename, fp
+    end
   end
 end


### PR DESCRIPTION
**NOTE**: this is an idea that I have to support [this usecase](https://github.com/theforeman/prprocessor/pull/118#discussion_r211153786). I would love to hear what you think.

Currently you can set labels according to one of the root directories (`app`, `webpack`, etc). In other words, you cannot label a PR according to a file in `app/assets`.

This commit adds this feature. For example in `repos.yml`:

```yml
theforeman/foreman:
  directory_labels:
    app/assets: ui
    app/controllers: backend
    webpack: ui
```

it will add `ui` label if there were changed files in `./app/assets/` or `./webpack/` and `backend` label if
a file was changed in `./app/controllers`.

//cc : @ekohl  @ohadlevy  @tbrisker 
