### PR TITLE
[RFC] Add Foreman Branch labels

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -21,6 +21,7 @@ theforeman/foreman:
   redmine_required: true
   link_to_redmine: true
   directory_labels:
+    .+-stable: Stable branch
     webpack: UI
 theforeman/foreman_abrt:
   redmine: abrt


### PR DESCRIPTION
There are 2 ideas here:
* A label per release (1.18, 1.19)
* A generic Cherry pick label for all stable branches

Note that these labels currently don't actually exist so this should not be merged. I'm looking for opinions

cc @tbrisker