### PR TITLE
Fixes for the close inactive script

### DIFF
--- a/scripts/close_inactive.rb
+++ b/scripts/close_inactive.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'raven'
 require 'octokit'
 require 'pp'
 require 'date'

--- a/scripts/close_inactive.rb
+++ b/scripts/close_inactive.rb
@@ -10,6 +10,8 @@ require File.expand_path(File.join('..', '..', 'redmine', 'issue'), __FILE__)
 def close_prs(client, repo, config, label, time, message)
   query = "repo:#{repo} type:pr state:open label:\"#{label}\" updated:\"<#{time}\""
   result = client.search_issues(query, :per_page => CONFIG[:max_closed], :sort => 'updated_at', :order => 'asc')
+  return if result[:total_count] == 0
+
   puts "Pull requests older than #{time}: #{result[:total_count]}"
   result[:items].each do |pr|
     title = pr[:title]

--- a/scripts/close_inactive.rb
+++ b/scripts/close_inactive.rb
@@ -7,6 +7,33 @@ require File.expand_path(File.join('..', '..', 'repository'), __FILE__)
 require File.expand_path(File.join('..', '..', 'github', 'pull_request'), __FILE__)
 require File.expand_path(File.join('..', '..', 'redmine', 'issue'), __FILE__)
 
+def close_prs(client, repo, config, label, time, message)
+  query = "repo:#{repo} type:pr state:open label:\"#{label}\" updated:\"<#{time}\""
+  result = client.search_issues(query, :per_page => CONFIG[:max_closed], :sort => 'updated_at', :order => 'asc')
+  puts "Pull requests older than #{time}: #{result[:total_count]}"
+  result[:items].each do |pr|
+    title = pr[:title]
+    number = pr[:number]
+    user = pr[:user][:login]
+    updated_at = pr[:updated_at].to_datetime
+    labels = client.labels_for_issue(repo, number).collect{ |x| x[:name] }
+    if updated_at < time && labels.include?(label)
+      puts "Closing #{number} (#{title}) with latest update #{updated_at}"
+      client.add_comment(repo, number, message % user) if CONFIG[:add_comment]
+      client.add_labels_to_an_issue(repo, number, CONFIG[:labels]) if CONFIG[:add_labels]
+      client.close_pull_request(repo, number) if CONFIG[:close]
+
+      pr_obj = PullRequest.new(config, pr, client)
+      pr_obj.issue_numbers.map { |issue| Issue.new(issue) }.each do |issue|
+        issue.set_assigned(nil)
+        issue.set_status(Issue::NEW)
+        issue.remove_pull_request(pr[:html_url])
+        issue.save!
+      end
+    end
+  end
+end
+
 CONFIG = {}
 CONFIG.merge!(YAML.load_file('config/close_inactive.yaml'))
 CONFIG.merge!(YAML.load_file('config/local_close_inactive.yaml')) if File.exists?('config/local_close_inactive.yaml')
@@ -23,35 +50,8 @@ Thank you for your contribution, @%s! This PR has reached an impasse with no new
 Feel free to reopen if you feel an agreement can be reached. This is an automated process.
 EOC
 
-c = Octokit::Client.new(:access_token => ENV['GITHUB_OAUTH_TOKEN'])
+client = Octokit::Client.new(:access_token => ENV['GITHUB_OAUTH_TOKEN'])
 Repository.all.select { |repo,config| config.close_inactive? }.each do |repo,config|
-  close_prs(repo, config, "Waiting on contributor", inactive_time, inactive_comment)
-  close_prs(repo, config, "Reached an impasse", impasse_time, impasse_comment)
-end
-
-def close_prs(repo, config, label, time, message)
-  query = "repo:#{repo} type:pr state:open label:\"#{label}\" updated:\"<#{time}\""
-  result = c.search_issues(query, :per_page => CONFIG[:max_closed], :sort => 'updated_at', :order => 'asc')
-  puts "Pull requests older than #{time}: #{result[:total_count]}"
-  result[:items].each do |pr|
-    title = pr[:title]
-    number = pr[:number]
-    user = pr[:user][:login]
-    updated_at = pr[:updated_at].to_datetime
-    labels = c.labels_for_issue(repo, number).collect{ |x| x[:name] }
-    if updated_at < time && labels.include?(label)
-      puts "Closing #{number} (#{title}) with latest update #{updated_at}"
-      c.add_comment(repo, number, message % user) if CONFIG[:add_comment]
-      c.add_labels_to_an_issue(repo, number, CONFIG[:labels]) if CONFIG[:add_labels]
-      c.close_pull_request(repo, number) if CONFIG[:close]
-
-      pr_obj = PullRequest.new(config, pr, c)
-      pr_obj.issue_numbers.map { |issue| Issue.new(issue) }.each do |issue|
-        issue.set_assigned(nil)
-        issue.set_status(Issue::NEW)
-        issue.remove_pull_request(pr[:html_url])
-        issue.save!
-      end
-    end
-  end
+  close_prs(client, repo, config, "Waiting on contributor", inactive_time, inactive_comment)
+  close_prs(client, repo, config, "Reached an impasse", impasse_time, impasse_comment)
 end


### PR DESCRIPTION
* Require raven for error reporting
* Only output when there's something to close
* Move the close prs definition to the top