### PR TITLE
Set the target version to nil when backlog or recycle bin PRs are m…

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -63,7 +63,10 @@ EOM
           pull_request.add_comment(message)
         end
       elsif !issue.rejected?
-        issue.set_triaged(false) if issue.backlog? || issue.recycle_bin? || issue.version.nil?
+        if issue.backlog? || issue.recycle_bin? || issue.version.nil?
+          issue.set_triaged(false)
+          issue.set_target_version(nil)
+        end
         issue.add_pull_request(pull_request.raw_data['html_url']) unless pull_request.cherry_pick?
         issue.set_status(Issue::READY_FOR_TESTING) unless issue.closed? || pull_request.wip?
         issue.set_assigned(user_id) unless user_id.nil? || user_id.empty? || issue.assigned_to

--- a/redmine/issue.rb
+++ b/redmine/issue.rb
@@ -102,4 +102,9 @@ class Issue < RedmineResource
     "#{project} ##{@raw_data['issue']['id']}"
   end
 
+  def set_target_version(version)
+    # use nil to unset version
+    @raw_data['issue']["fixed_version_id"] = version
+    self
+  end
 end


### PR DESCRIPTION
…erged

We are not seeing the target version unset when a backlog PR is merged. This
should update the PR's version to nil, which unsets it. I've used the "fixed_version_id" = nil
syntax in another script and it worked well to unset the version.