### PR TITLE
Complete WIP check removal

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -54,7 +54,7 @@ post '/pull_request' do
           issue.set_target_version(nil)
         end
         issue.add_pull_request(pull_request.raw_data['html_url']) unless pull_request.cherry_pick?
-        issue.set_status(Issue::READY_FOR_TESTING) unless issue.closed? || pull_request.wip?
+        issue.set_status(Issue::READY_FOR_TESTING) unless issue.closed?
         issue.set_assigned(user_id) unless user_id.nil? || user_id.empty? || issue.assigned_to
         begin
           issue.save!


### PR DESCRIPTION
6877213ef97781fe6c8ece188d17b6798f6bbb51 removed the wip? method but failed to remove all callers. This completes that part.