### PR TITLE
Add smart_proxy_container_gateway smart proxy plugin

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -244,5 +244,9 @@ Katello/katello-selinux:
   redmine: katello
 Katello/runcible:
   redmine: runcible
+Katello/smart_proxy_container_gateway:
+  redmine: katello
+  redmine_required: true
+  link_to_redmine: true
 theforeman/stats-dashboard:
   redmine: stats-dashboard


### PR DESCRIPTION
https://github.com/Katello/smart_proxy_container_gateway

This is an in-development smart proxy plugin that will allow users to use `podman` with Pulp 3-enabled smart proxies. 