### PR TITLE
Reintroduce Python 3.7 compatibility

### DIFF
--- a/prprocessor/__main__.py
+++ b/prprocessor/__main__.py
@@ -13,6 +13,7 @@ from octomachinery.app.server.runner import run as run_app
 from pkg_resources import resource_filename
 from redminelib.resources import Issue, Project
 
+from prprocessor.compat import strip_suffix
 from prprocessor.redmine import (Field, Status, get_issues, get_latest_open_version, get_redmine,
                                  set_fixed_in_version, verify_issues, IssueValidation)
 
@@ -342,7 +343,7 @@ async def on_pr_merge(*, pull_request: Mapping, **other) -> None:  # pylint: dis
     if target_branch.endswith('-stable'):
         # Handle a branch like 3.0-stable. This means we get an additional prefix of 3.0. which
         # allows get_latest_open_version to find the right version
-        version_prefix = f'{target_branch.removesuffix("-stable")}.'
+        version_prefix = f'{strip_suffix(target_branch, "-stable")}.'
     elif target_branch in ('main', 'master', 'develop', 'deb/develop', 'rpm/develop'):
         # Development branches don't have a version prefix so they really use the latest
         version_prefix = ''

--- a/prprocessor/compat.py
+++ b/prprocessor/compat.py
@@ -1,0 +1,28 @@
+def strip_suffix(value: str, suffix: str) -> str:
+    """
+    Remove the suffix like Python 3.9+ str.removesuffix does.
+
+    >>> strip_suffix('2.4-stable', '-stable')
+    '2.4'
+    >>> strip_suffix('develop', '-stable')
+    'develop'
+    """
+    if value.endswith(suffix):
+        return value[:-len(suffix)]
+    return value
+
+
+def strip_prefix(value: str, prefix: str) -> str:
+    """
+    Remove the prefix like Python 3.9+ str.removeprefix does.
+
+    >>> strip_prefix('foreman-3.3', 'foreman-')
+    '3.3'
+    >>> strip_prefix('katello-4.4', 'foreman-')
+    'katello-4.4'
+    >>> strip_prefix('develop', 'foreman-')
+    'develop'
+    """
+    if value.startswith(prefix):
+        return value[len(prefix):]
+    return value

--- a/prprocessor/redmine.py
+++ b/prprocessor/redmine.py
@@ -9,6 +9,8 @@ from redminelib import Redmine
 from redminelib.exceptions import ResourceNotFoundError
 from redminelib.resources import CustomField, Issue, Project
 
+from prprocessor.compat import strip_prefix
+
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -124,6 +126,6 @@ def _filter_versions(versions: Iterable[CustomField],
                      version_prefix: str) -> Generator[CustomField, None, None]:
     for version in versions:
         if version.name.startswith(version_prefix):
-            name = version.name.removeprefix(version_prefix)
+            name = strip_prefix(version.name, version_prefix)
             if name and name[0].isdigit():
                 yield version

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
         'python-redmine',
     ],
     package_data={'prprocessor': ['config/*.yaml']},
-    python_requires='>= 3.9',
+    python_requires='>= 3.7',
 )


### PR DESCRIPTION
On OpenShift there's an easy Python 3.8 s2i container but no Python 3.9 version. There is very little code which actually needs 3.9 so reverting this is easier than finding some 3.9 container.

This reverts commits 42b32f6984cc97ca4ff5638a23949d5de2165ed3 and fa5b5d17873653ba356c9f1b6b3c2eb780ad49e6 while also fixing 7e59d7d4c025a6854483cfbc5bbdbd46b3f22361 to be Python < 3.9 compatible again.