### PR TITLE
Require at least octomachinery 0.3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=['prprocessor'],
     install_requires=[
         'PyYAML',
-        'octomachinery',
+        'octomachinery >= 0.3.11',
         'python-redmine',
     ],
     package_data={'prprocessor': ['config/*.yaml']},


### PR DESCRIPTION
As mentioned in https://github.com/sanitizers/octomachinery/issues/66#issuecomment-2313673606, this contains fixes needed to work with how GitHub sends their webhooks now.